### PR TITLE
feat(navbar y webpack): local base y arrastrar y soltar

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -76,6 +76,20 @@ export default function Navbar() {
 			}
 		}
 	}, [])
+
+	const handleDragOver = (event) => {
+		event.preventDefault(); // Necesario para permitir el evento de soltar
+	};
+	  
+	const handleDrop = (event) => {
+		event.preventDefault();
+		const files = event.dataTransfer.files; // Accede a los archivos arrastrados
+		if (files && files.length) {
+			const fileEvent = { target: { files } }; // Simula el evento onChange del input
+		  	readExcelFile(fileEvent);
+		}
+	};
+
 	return (
 		<header className={'sidebar ' + openNav}>
 			{/* {cabcera buscador logo} */}
@@ -147,7 +161,7 @@ export default function Navbar() {
 						<div className="templates-xls--left">
 							<form className="file-upload-form">
 								<label htmlFor="file" className="file-upload-label">
-									<div className="file-upload-design">
+									<div className="file-upload-design" onDragOver={handleDragOver} onDrop={handleDrop}>
 										<svg viewBox="0 0 640 512" height="1em">
 											<path d="M144 480C64.5 480 0 415.5 0 336c0-62.8 40.2-116.2 96.2-135.9c-.1-2.7-.2-5.4-.2-8.1c0-88.4 71.6-160 160-160c59.3 0 111 32.2 138.7 80.2C409.9 102 428.3 96 448 96c53 0 96 43 96 96c0 12.2-2.3 23.8-6.4 34.6C596 238.4 640 290.1 640 352c0 70.7-57.3 128-128 128H144zm79-217c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l39-39V392c0 13.3 10.7 24 24 24s24-10.7 24-24V257.9l39 39c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0l-80 80z"></path>
 										</svg>
@@ -165,7 +179,7 @@ export default function Navbar() {
 							{templatesDDBB.length > 0 ? (
 								templatesDDBB.map((template, i) => {
 									return (
-										<a class="container-btn-file" href="#">
+										<a className="container-btn-file" href={`noTocar/plantillas/${template}.xlsx`} key={i}>
 											<svg
 												fill="#fff"
 												xmlns="http://www.w3.org/2000/svg"

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -61,6 +61,11 @@ module.exports = {
 					to: 'noTocar/imagenes',
 					noErrorOnMissing: true,
 				},
+				{
+					from: path.join(__dirname, '/src/assets/files/plantillas'),
+					to: 'noTocar/plantillas',
+					noErrorOnMissing: true,
+				},
 			],
 		}),
 	],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,11 @@ module.exports = {
 					to: 'noTocar/imagenes',
 					noErrorOnMissing: true,
 				},
+				{
+					from: path.join(__dirname, '/src/assets/files/plantillas'),
+					to: 'noTocar/plantillas',
+					noErrorOnMissing: true,
+				},
 			],
 		}),
 	],


### PR DESCRIPTION
en el navbar se añade la funcionalidad de arrastrar y soltar ademas en assets se deja una carpeta files y dentro de esta una carpeta llamada plantillas para alojar las plantillas a descargar y se usa copyplugin para tener estas plantillas en noTocar